### PR TITLE
fix readme and description

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # clone
 
-  Object or Array shallow copy.
+  Object or Array deep copy.
 
 ## Installation
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "shallow",
   "repo": "bredele/shallow",
-  "description": "Object/Array shallow copy",
+  "description": "Object/Array deep copy",
   "version": "1.0.0",
   "keywords": [],
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bredele-clone",
   "version": "1.0.0",
-  "description": "Object/Array shallow copy",
+  "description": "Object/Array deep copy",
   "main": "index.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Github description says it's a deep copy, which is true, but README and other descriptions contradict.

This patch fixes it so that fellow developers won't be confused.
